### PR TITLE
Fix building on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint --ext .js,.vue --fix src",
-    "dev": "node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js",
-    "build": "node_modules/webpack/bin/webpack.js --hide-modules -p --progress"
+    "dev": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js",
+    "build": "node ./node_modules/webpack/bin/webpack.js --hide-modules -p --progress"
   },
   "dependencies": {
     "flatpickr": "^3.0.6"


### PR DESCRIPTION
This pull request fixes two issues, both of which are prevent `npm run dev` from running cleanly under Windows.

The first issue is reproducible by running `npm run dev`, which gives:
```
$ npm run dev

> vue-flatpickr-component@2.4.0 dev C:\msys64\home\klinden\vue-flatpickr-component
> node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js

'node_modules' is not recognized as an internal or external command,
operable program or batch file.

npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "dev"
npm ERR! node v6.11.0
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! vue-flatpickr-component@2.4.0 dev: `node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the vue-flatpickr-component@2.4.0 dev script 'node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the vue-flatpickr-component package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs vue-flatpickr-component
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls vue-flatpickr-component
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     C:\msys64\home\klinden\vue-flatpickr-component\npm-debug.log
```
See for example [issue 151 of laravel-mix](https://github.com/JeffreyWay/laravel-mix/issues/151) for another occurence of this error. The issue is fixed by prepending `node` to the scripts in `package.json`.

After fixing the first issue the second issue is reproduced by running `npm run dev` again after which one gets the following warnings.
```
$ npm run dev

> vue-flatpickr-component@2.4.0 dev C:\msys64\home\klinden\vue-flatpickr-component
> node node_modules/webpack-dev-server/bin/webpack-dev-server.js --config=webpack.config.dev.js

Project is running at http://localhost:8080/
webpack output is served from /
Content not from webpack is served from C:\msys64\home\klinden\vue-flatpickr-component\examples
webpack: wait until bundle finished: /

WARNING in ./src/flatPickr.vue
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Use equal casing. Compare these module identifiers:
* C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\index.js!C:\msys64\home\klinden\vue-flatpickr-component\src\flatPickr.vue
    Used by 1 module(s), i. e.
    C:\msys64\home\klinden\vue-flatpickr-component\node_modules\babel-loader\lib\index.js!C:\msys64\home\klinden\vue-flatpickr-component\src\index.js
* C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\index.js!C:\msys64\home\klinden\vue-flatpickr-component\src\flatpickr.vue
    Used by 3 module(s), i. e.
    multi C:\msys64\home\klinden\vue-flatpickr-component\node_modules\webpack-dev-server\client\index.js?http://localhost:8080 webpack/hot/dev-server vue flatpickr jquery bootstrap

WARNING in ./~/babel-loader/lib!./~/vue-loader/lib/selector.js?type=script&index=0!./src/flatPickr.vue
There are multiple modules with names that only differ in casing.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Use equal casing. Compare these module identifiers:
* C:\msys64\home\klinden\vue-flatpickr-component\node_modules\babel-loader\lib\index.js!C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\lib\selector.js?type=script&index=0!C:\msys64\home\klinden\vue-flatpickr-component\src\flatPickr.vue
    Used by 1 module(s), i. e.
    C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\index.js!C:\msys64\home\klinden\vue-flatpickr-component\src\flatPickr.vue
* C:\msys64\home\klinden\vue-flatpickr-component\node_modules\babel-loader\lib\index.js!C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\lib\selector.js?type=script&index=0!C:\msys64\home\klinden\vue-flatpickr-component\src\flatpickr.vue
    Used by 1 module(s), i. e.
    C:\msys64\home\klinden\vue-flatpickr-component\node_modules\vue-loader\index.js!C:\msys64\home\klinden\vue-flatpickr-component\src\flatpickr.vue
webpack: Compiled with warnings.
```
In the resulting webapp no datepickers work because the wrong flatpickr is imported in `src/flatPickr.vue`, since Windows does not distinguish between upper and lower case. A fix is renaming that file to `src/vue-flatpickr.vue` and changing the only user `src/index.js` accordingly.

The addition in LICENSE.txt and the license header in `src/index.js` are due to Bombardier Transportation's (my employer's) rules for contributing to open source projects, such as this one.