### PR TITLE
Clear date on keyup.delete

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Ankur Kumar
+Copyright (c) 2017 Bombardier Transportation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "datepicker"
   ],
   "author": "ankurk91",
+  "contributors": [
+    {
+      "name": "Bombardier Transportation",
+      "url": "http://www.bombardier.com/en/transportation.html"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/ankurk91/vue-flatpickr-component/issues"

--- a/src/flatPickr.vue
+++ b/src/flatPickr.vue
@@ -1,3 +1,19 @@
+<!--
+ (C) Copyright 2017 Bombardier Transportation.
+
+ All rights reserved. This program and the accompanying materials
+ are made available under the terms of the MIT and is available at
+ https://opensource.org/licenses/MIT
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Developer: Karl Linden (klinden)
+-->
+
 <template>
 
   <input type="text"
@@ -8,6 +24,7 @@
          :placeholder="placeholder"
          :required="required"
          v-model="mutableValue"
+         @keyup.delete="mutableValue = null"
          data-input>
 
 </template>


### PR DESCRIPTION
With this change, the datepicker is cleared whenever it has focus and the user hits "Delete" or "Backspace". It is introduced unconditionally since it is a very natural standard behaviour.