### PR TITLE
Fix Error in nextTick: "TypeError: Cannot read property 'value' of null"

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -101,9 +101,10 @@ export default {
      * @param event
      */
     onInput(event) {
+      const value = event.target.value;
       // Lets wait for DOM to be updated
       this.$nextTick(() => {
-        this.$emit('input', event.target.value);
+        this.$emit('input', value);
       });
     },
 


### PR DESCRIPTION
I've found the trigger for this #132 bug.
The bug happens when the vue-flatpickr-component is used inside a vue app that is wrapped in a webcomponent.
After a deep debug session I've found that event.target during the $nextTick callback run called in onInput handler is null when the flatpickr is used in a vue app wrapped in a webcomponent.
This little fix does the trick.