### PR TITLE
Destroy Flatpickr  when component is completely destroyed

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -188,7 +188,7 @@ export default {
   /**
    * Free up memory
    */
-  beforeDestroy() {
+  destroyed() {
     /* istanbul ignore else */
     if (this.fp) {
       this.fpInput().removeEventListener('blur', this.onBlur);


### PR DESCRIPTION
When the component inside `transition` tag is destroyed, the Flatpickr remains visible for some time. It's bad for UX. The solution is to destroy Flatpickr  when component is completely destroyed.