### PR TITLE
Fix error if flatpickr instance not yet set

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -174,6 +174,10 @@ export default {
     config: {
       deep: true,
       handler(newConfig) {
+        if (!this.fp) {
+          return;
+        }
+
         let safeConfig = cloneObject(newConfig);
         // Workaround: Don't pass hooks to configs again otherwise
         // previously registered hooks will stop working


### PR DESCRIPTION
In some situations like when navigating to a page with vue-router / inertiajs that is having this component you will see `Uncaught (in promise) TypeError: Cannot read property 'emitsOptions' of null`

I updated the code so it check that the flatpickr instance is set before trying to update its options.