### PR TITLE
Add exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.umd.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    "import": "./dist/esm/index.js",
+    "require": "./dist/index.umd.js"
+  },
   "files": [
     "src",
     "dist",


### PR DESCRIPTION
This should allow consumers to import the ESM or UMD build depending on the project type.

Fixes #283