### PR TITLE
Export types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     "import": "./dist/esm/index.js",
-    "require": "./dist/index.umd.js"
+    "require": "./dist/index.umd.js",
+    "types": "./dist/types/index.d.ts"
   },
   "files": [
     "src",


### PR DESCRIPTION
Since a list of `exports` has been added to the `package.json`, types could no longer be found, as these need to be exported as well.